### PR TITLE
.NET 6 対応

### DIFF
--- a/Asn1PKCS/Asn1PKCS.csproj
+++ b/Asn1PKCS/Asn1PKCS.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard13;netstandard20</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard13;netstandard20;net6.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AssemblyTitle>Asn1PKCS</AssemblyTitle>
     <Product>Asn1PKCS</Product>

--- a/Asn1PKCSTest/Asn1PKCSTest.csproj
+++ b/Asn1PKCSTest/Asn1PKCSTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp20</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -14,9 +14,9 @@
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
.NET 6 からアセンブリのトリム機能が強化されたなどもあったので、対応していただけるととても嬉しいです
明示的に対応させなくても.NET 6 SDKでビルドし直してnugetパッケージを更新するだけでも大丈夫かと思います(その辺りよくわかっていない)